### PR TITLE
Refactor: Improve graph generation, output configuration, and documen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Gradle Plugin Portal Version](https://img.shields.io/gradle-plugin-portal/v/io.github.esneiderfjaimes.modgraph?color=%2302303a)](https://plugins.gradle.org/plugin/io.github.esneiderfjaimes.modgraph)
 
-A Gradle plugin that generates visual diagrams of module dependencies in multi-module projects.  
-Currently supports output via the Graphviz `dot` command. Future support for other providers like Mermaid is planned.
+A Gradle plugin that generates visual diagrams of module dependencies in multi-module projects.
 
 ---
 
@@ -11,7 +10,7 @@ Currently supports output via the Graphviz `dot` command. Future support for oth
 
 ```kotlin
 plugins {
-    id("io.github.esneiderfjaimes.modgraph") version "0.0.1"
+    id("io.github.esneiderfjaimes.modgraph") version "<version>"
 }
 ```
 
@@ -21,8 +20,7 @@ plugins {
 
 * Detects dependencies between modules in your Gradle project.
 * Generates a diagram (SVG) of the module dependency graph.
-* Saves the output to the `docs/graphs/` directory.
-* Currently, requires a provider to be specified (e.g., `graphviz`).
+* Saves the output to the `docs/graphs/` directory by default.
 
 ---
 
@@ -48,21 +46,26 @@ your-project/
 ### 1. Run the Graph Generator
 
 ```bash
-./gradlew generateModuleDependencyGraph --provider=graphviz
+./gradlew generateModuleDependencyGraph
 ```
 
-This will scan your modules and generate an SVG diagram at `docs/graphs/`.
+You can optionally specify parameters:
+
+```bash
+./gradlew generateModuleDependencyGraph \
+  --output=custom/output/path \
+  --module=:app
+```
 
 ---
 
-### 2. Configuration (via Extension – optional for future versions)
+### 2. Configuration via Extension
 
-The plugin includes a `modGraph` extension for future configuration, such as customizing the output directory.
+Instead of passing CLI arguments, you can configure the plugin using the `modGraph` extension in your root `build.gradle.kts`:
 
 ```kotlin
 modGraph {
-    // Example (not yet implemented)
-    // output.set(file("custom/path"))
+    outputDirPath.set("${rootDir}/custom/output")
 }
 ```
 
@@ -76,20 +79,31 @@ modGraph {
 
 ---
 
+## 🔧 Task Options
+
+| Option     | Type   | Required | Description                                |
+|------------|--------|----------|--------------------------------------------|
+| `--output` | String | ❌        | Output directory (default: `docs/graphs/`) |
+
+---
+
 ## 💡 Notes
 
-* The `--provider` flag is required. The only supported value for now is:
-    - `graphviz`: Requires [Graphviz](https://graphviz.org/) installed and accessible via the `dot` command in your terminal.
+* Only project-to-project dependencies are shown (e.g., `implementation(project(":core"))`).
+* If the output directory doesn't exist, it will be created automatically.
+* You can define options either via CLI flags or the extension (`modGraph`), with extension values taking precedence.
 
-* Output is always saved to `docs/graphs/`.
-* Only project module dependencies are considered (e.g., `implementation(project(":core"))`).
+---
+
+## 🙌 Credits
+
+SVG generation is powered by the excellent [Graphviz Java library by nidi3](https://github.com/nidi3/graphviz-java).
 
 ---
 
 ## 🔜 Planned Features
 
 * Support for Mermaid diagrams.
-* Configurable output path.
-* Additional output formats (e.g., `.dot`, `.md`, etc.).
+* Additional output formats (`.dot`, `.md`, etc.).
 
 ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,14 @@ plugins {
 }
 
 group = "io.github.esneiderfjaimes"
-version = "0.0.2"
+version = "0.0.3"
 
 repositories {
     mavenCentral()
+}
+
+dependencies {
+    implementation("guru.nidi:graphviz-java:0.18.1")
 }
 
 gradlePlugin {

--- a/src/main/kotlin/io/github/esneiderfjaimes/modgraph/ModGraphExtension.kt
+++ b/src/main/kotlin/io/github/esneiderfjaimes/modgraph/ModGraphExtension.kt
@@ -1,5 +1,9 @@
 package io.github.esneiderfjaimes.modgraph
 
-open class ModGraphExtension {
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
 
+abstract class ModGraphExtension @Inject constructor(objects: ObjectFactory) {
+    val outputDirPath: Property<String> = objects.property(String::class.java)
 }

--- a/src/main/kotlin/io/github/esneiderfjaimes/modgraph/ModGraphPlugin.kt
+++ b/src/main/kotlin/io/github/esneiderfjaimes/modgraph/ModGraphPlugin.kt
@@ -6,12 +6,8 @@ import org.gradle.kotlin.dsl.register
 
 @Suppress("unused")
 class ModGraphPlugin : Plugin<Project> {
-    override fun apply(target: Project) = with(target) {
-        if (this == rootProject) {
-            val extension = extensions.create("modGraph", ModGraphExtension::class.java)
-            tasks.register("generateModuleDependencyGraph", GenerateModGraphTask::class) {
-                outputDir.set(layout.projectDirectory.dir("docs/graphs"))
-            }
-        }
+    override fun apply(target: Project): Unit = with(target) {
+        val extension = extensions.create("modGraph", ModGraphExtension::class.java)
+        tasks.register("generateModuleDependencyGraph", GenerateModGraphTask::class)
     }
 }

--- a/src/main/kotlin/io/github/esneiderfjaimes/modgraph/core/Ext.kt
+++ b/src/main/kotlin/io/github/esneiderfjaimes/modgraph/core/Ext.kt
@@ -1,8 +1,7 @@
 package io.github.esneiderfjaimes.modgraph.core
 
 fun String.normalizeId(): String {
-    return replace(":", "_").replace("-", "_").removePrefix("_")
+    return removePrefix(":")
+        .replace(":", "__")
+        .replace("-", "___")
 }
-
-const val SHOW_LOG = false
-const val SHOW_DANGER_LOG = false

--- a/src/main/kotlin/io/github/esneiderfjaimes/modgraph/core/GraphGenerator.kt
+++ b/src/main/kotlin/io/github/esneiderfjaimes/modgraph/core/GraphGenerator.kt
@@ -1,18 +1,18 @@
 package io.github.esneiderfjaimes.modgraph.core
 
-import io.github.esneiderfjaimes.modgraph.GenerateModGraphTask
+import io.github.esneiderfjaimes.modgraph.GenerateModGraphTask.GraphProvider
 import io.github.esneiderfjaimes.modgraph.core.providers.GraphvizBuilder
 import io.github.esneiderfjaimes.modgraph.core.providers.MermaidBuilder
 
 class GraphGenerator(val provider: ProjectProvider) {
-    fun generate(moduleName: String, graphProvider: GenerateModGraphTask.GraphProvider): String {
+    fun generate(moduleName: String, graphProvider: GraphProvider): String {
         val module = provider.getModuleByPath(moduleName)
         val paths = mutableListOf(module.path)
         paths += getAllDependenciesPaths(module)
         val map = transformPathsToDirectories(paths)
         return when (graphProvider) {
-            GenerateModGraphTask.GraphProvider.MERMAID -> MermaidBuilder().create(module, map)
-            GenerateModGraphTask.GraphProvider.GRAPHVIZ -> GraphvizBuilder().create(module, map)
+            GraphProvider.MERMAID -> MermaidBuilder().create(module, map)
+            GraphProvider.GRAPHVIZ -> GraphvizBuilder().create(module, map)
         }
     }
 

--- a/src/test/kotlin/io/github/esneiderfjaimes/modgraph/GraphGeneratorTest.kt
+++ b/src/test/kotlin/io/github/esneiderfjaimes/modgraph/GraphGeneratorTest.kt
@@ -41,15 +41,15 @@ digraph unix {
 		color = lightgrey;
 		style = dashed;
 
-		core_data_id [label=":core:data"];
-		core_model_id [label=":core:model"];
-		core_api_id [label=":core:api"];
-		core_database_id [label=":core:database"];
+		core__data_id [label=":core:data"];
+		core__model_id [label=":core:model"];
+		core__api_id [label=":core:api"];
+		core__database_id [label=":core:database"];
 	}
 
-	app_id -> {core_data_id core_model_id core_api_id} [color=red];
-	core_data_id -> {core_api_id core_database_id core_model_id};
-	core_api_id -> {core_model_id};
+	app_id -> {core__data_id core__model_id core__api_id} [color=red];
+	core__data_id -> {core__api_id core__database_id core__model_id};
+	core__api_id -> {core__model_id};
 }""".trimIndent()
 
     val rawMERMAID = """
@@ -58,15 +58,15 @@ graph TD
 	app_id(:app)
 
 	subgraph core
-		core_data_id(:core:data)
-		core_model_id(:core:model)
-		core_api_id(:core:api)
-		core_database_id(:core:database)
+		core__data_id(:core:data)
+		core__model_id(:core:model)
+		core__api_id(:core:api)
+		core__database_id(:core:database)
 	end
 
-app_id --> core_data_id & core_model_id & core_api_id
-core_data_id --> core_api_id & core_database_id & core_model_id
-core_api_id --> core_model_id
+app_id --> core__data_id & core__model_id & core__api_id
+core__data_id --> core__api_id & core__database_id & core__model_id
+core__api_id --> core__model_id
 """.trimIndent()
     @Test
     fun `should content syntax graphviz`() {


### PR DESCRIPTION
…tation

This commit introduces several enhancements to the ModGraph plugin:

**Core Functionality:**

- **Direct SVG Generation with Graphviz-Java:** The plugin now directly uses the `guru.nidi:graphviz-java` library to generate SVG files from Graphviz `dot` syntax. This removes the previous dependency on having the `dot` command-line tool installed and in the system PATH. The `provider` option has been removed as Graphviz is now the default and only internal mechanism for SVG generation.
- **Configurable Output Directory:**
    - The output directory for generated graphs can now be configured via the `modGraph` extension in `build.gradle.kts` using `outputDirPath.set("path/to/graphs")`.
    - An `--output` command-line option is also available for the `generateModuleDependencyGraph` task to override the configured or default path.
    - The default output directory remains `docs/graphs/` in the root project.
- **Single Module Graph Generation:**
    - A new optional `--module` command-line option allows generating a dependency graph for a specific module (e.g., `--module=:app`).
    - If `--module` is not specified and the task is run from the root project, graphs for all subprojects will be generated.
    - If run from a subproject without `--module`, only the graph for that subproject is generated.
- **Improved Node ID Normalization:** The `normalizeId()` function has been updated to produce more Graphviz-compatible IDs by replacing `:` with `__` and `-` with `___`, and removing the leading colon.

**Build and Dependencies:**

- Added `guru.nidi:graphviz-java:0.18.1` as an implementation dependency.
- Plugin version bumped to `0.0.3`.

**Task and Extension Changes:**

- `GenerateModGraphTask`:
    - Removed the `provider` property.
    - Added `outputDirPath` and `moduleName` properties with corresponding `--output` and `--module` CLI options.
    - `outputDirPath` defaults to `docs/graphs` or the value from the `modGraph` extension.
    - Logic updated to use `graphviz-java` for direct SVG rendering.
    - Handles absolute and relative paths for the output directory.
    - Improved error message for non-existent modules.
- `ModGraphExtension`:
    - Added `outputDirPath` property for configuring the output directory.
- `ModGraphPlugin`:
    - Task registration simplified; output directory configuration is now handled within the task itself using the extension or defaults.

**Testing:**

- `ModGraphPluginTest`:
    - Updated tests to reflect the removal of the `--provider` option.
    - Added a new test case `should generate svg file with module dependencies custom output` to verify the `--output` option.
- `GraphGeneratorTest`:
    - Expected Graphviz output updated to match the new node ID normalization.

**Documentation (README.md):**

- Updated plugin version.
- Removed references to the `--provider` flag.
- Added information about configuring the output path via the `modGraph` extension and the `--output` CLI option.
- Added information about the `--module` CLI option.
- Clarified that Graphviz is now used internally via a Java library.
- Added a "Credits" section mentioning `graphviz-java`.
- Updated "Planned Features" to remove "Configurable output path" as it's now implemented.